### PR TITLE
feat: format metric obj

### DIFF
--- a/swankit/callback/models/key.py
+++ b/swankit/callback/models/key.py
@@ -211,13 +211,19 @@ class MetricInfo:
         return self.column_info.error
 
     @property
-    def data(self) -> Union[Dict, None]:
+    def data(self):
         """
         指标数据的data字段
         """
         if self.is_error:
             return None
         return self.metric["data"]
+
+    def __str__(self):
+        return str(self.data)
+
+    def __repr__(self):
+        return str(self.data)
 
 
 class MetricErrorInfo(MetricInfo):

--- a/test/unit/callback/models/test_key.py
+++ b/test/unit/callback/models/test_key.py
@@ -109,3 +109,5 @@ def test_metric_info():
     assert m.metric_epoch == 1
     assert m.swanlab_media_dir == "."
     assert m.metric_file_path == f"./{c.kid}/1.log"
+    assert str(m) == "1"
+    assert repr(m) == "1"


### PR DESCRIPTION
This pull request includes changes to the `swankit/callback/models/key.py` file and its corresponding test file to improve the handling and representation of metric data. The most important changes include the addition of `__str__` and `__repr__` methods to the `MetricInfo` class and corresponding tests to ensure these methods work as expected.

For https://github.com/SwanHubX/SwanLab/issues/816

Improvements to `MetricInfo` class:

* [`swankit/callback/models/key.py`](diffhunk://#diff-682a09402de1d3347b4f0f2c7dafcbdb38e9d12ef0bdfecb8e21182af4628970L214-R227): Added `__str__` and `__repr__` methods to the `MetricInfo` class to return the string representation of the `data` attribute.

Corresponding test updates:

* [`test/unit/callback/models/test_key.py`](diffhunk://#diff-8ec19d96668863f9ae510f7386c0b8c68e35f55b8cb5d952044cff66009abbdbR112-R113): Added assertions to test the `__str__` and `__repr__` methods of the `MetricInfo` class.