### PR TITLE
chore: echarts type and add settings property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "swankit"
-version = "0.1.7"
+version = "0.1.8"
 dynamic = ["readme", "dependencies"]
 description = "Base toolkit for SwanLab"
 license = "Apache-2.0"

--- a/swankit/core/data.py
+++ b/swankit/core/data.py
@@ -153,6 +153,8 @@ class BaseType(ABC, DynamicProperty):
 
         MOLECULE = ChartItem("molecule", "MOLECULE")
 
+        ECHARTS = ChartItem("echarts", "ECHARTS")
+
     # ---------------------------------- 需要子类实现的方法 ----------------------------------
 
     @abstractmethod

--- a/swankit/core/settings.py
+++ b/swankit/core/settings.py
@@ -8,7 +8,7 @@ r"""
     swankit 为 swanlab 定制的配置类
 """
 import os
-from typing import Tuple
+from typing import Tuple, List, Optional
 
 
 class LazySettings:
@@ -20,6 +20,7 @@ class LazySettings:
         self.__exp_name = None
         self.__exp_colors = None
         self.__description = None
+        self.__tags = None
 
     @property
     def exp_name(self) -> str:
@@ -36,7 +37,7 @@ class LazySettings:
         self.__exp_name = exp_name
 
     @property
-    def exp_colors(self) -> Tuple[str, str]:
+    def exp_colors(self) -> Optional[Tuple[str, str]]:
         """实验颜色"""
         return self.__exp_colors
 
@@ -48,7 +49,7 @@ class LazySettings:
         self.__exp_colors = exp_colors
 
     @property
-    def description(self) -> str:
+    def description(self) -> Optional[str]:
         """实验描述"""
         return self.__description
 
@@ -58,6 +59,16 @@ class LazySettings:
         if self.__description is not None:
             raise ValueError("description can only be set once")
         self.__description = description
+    
+    @property
+    def tags(self) -> Optional[List[str]]:
+        return self.__tags
+    
+    @tags.setter
+    def tags(self, tags:List[str]) -> None:
+        if self.__tags is not None:
+            raise ValueError("tags can only be set once")
+        self.__tags = tags
 
 
 class SwanLabSharedSettings(LazySettings):

--- a/swankit/core/settings.py
+++ b/swankit/core/settings.py
@@ -59,13 +59,15 @@ class LazySettings:
         if self.__description is not None:
             raise ValueError("description can only be set once")
         self.__description = description
-    
+
     @property
     def tags(self) -> Optional[List[str]]:
+        """实验标签"""
         return self.__tags
-    
+
     @tags.setter
-    def tags(self, tags:List[str]) -> None:
+    def tags(self, tags: List[str]) -> None:
+        """实验标签"""
         if self.__tags is not None:
             raise ValueError("tags can only be set once")
         self.__tags = tags

--- a/test/unit/core/test_settings.py
+++ b/test/unit/core/test_settings.py
@@ -5,6 +5,8 @@
 @description: 测试 settings
 """
 
+import pytest
+
 
 def test_lazy_settings():
     from swankit.core.settings import LazySettings
@@ -18,17 +20,9 @@ def test_lazy_settings():
     assert settings.exp_colors == ("red", "blue")
     assert settings.description == "test description"
 
-    try:
+    with pytest.raises(ValueError, match="exp_name can only be set once"):
         settings.exp_name = "test2"
-    except ValueError as e:
-        assert str(e) == "exp_name can only be set once"
-
-    try:
+    with pytest.raises(ValueError, match="exp_colors can only be set once"):
         settings.exp_colors = ("green", "yellow")
-    except ValueError as e:
-        assert str(e) == "exp_colors can only be set once"
-
-    try:
+    with pytest.raises(ValueError, match="description can only be set once"):
         settings.description = "test description 2"
-    except ValueError as e:
-        assert str(e) == "description can only be set once"

--- a/test/unit/core/test_settings.py
+++ b/test/unit/core/test_settings.py
@@ -1,0 +1,34 @@
+"""
+@author: cunyue
+@file: test_settings.py
+@time: 2025/5/15 18:15
+@description: 测试 settings
+"""
+
+
+def test_lazy_settings():
+    from swankit.core.settings import LazySettings
+
+    settings = LazySettings()
+    settings.exp_name = "test"
+    settings.exp_colors = ("red", "blue")
+    settings.description = "test description"
+
+    assert settings.exp_name == "test"
+    assert settings.exp_colors == ("red", "blue")
+    assert settings.description == "test description"
+
+    try:
+        settings.exp_name = "test2"
+    except ValueError as e:
+        assert str(e) == "exp_name can only be set once"
+
+    try:
+        settings.exp_colors = ("green", "yellow")
+    except ValueError as e:
+        assert str(e) == "exp_colors can only be set once"
+
+    try:
+        settings.description = "test description 2"
+    except ValueError as e:
+        assert str(e) == "description can only be set once"


### PR DESCRIPTION
This pull request includes updates to the `swankit` library, focusing on versioning, feature additions, and enhancements to the `LazySettings` class. It also introduces a new unit test for the `LazySettings` class. Below are the key changes grouped by theme:

### Versioning Update:
* Updated the version in `pyproject.toml` from `0.1.7` to `0.1.8` to reflect new changes.

### Feature Additions:
* Added a new chart type, `ECHARTS`, to the `ChartItem` enumeration in `swankit/core/data.py`.
* Introduced a new `tags` property in the `LazySettings` class, allowing optional tagging with a setter that enforces immutability after the first assignment. [[1]](diffhunk://#diff-c1b85b67ddf05b830f2e23a3e63702a10697078baa559f9cf014966a43da3906R23) [[2]](diffhunk://#diff-c1b85b67ddf05b830f2e23a3e63702a10697078baa559f9cf014966a43da3906R63-R72)

### Enhancements to `LazySettings`:
* Updated type hints for several properties in `LazySettings` (`exp_colors`, `description`) to make them optional, improving flexibility. [[1]](diffhunk://#diff-c1b85b67ddf05b830f2e23a3e63702a10697078baa559f9cf014966a43da3906L39-R40) [[2]](diffhunk://#diff-c1b85b67ddf05b830f2e23a3e63702a10697078baa559f9cf014966a43da3906L51-R52)

### Unit Testing:
* Added a new unit test, `test_lazy_settings`, in `test/unit/core/test_settings.py` to validate the behavior of the `LazySettings` class, including immutability checks for properties.