### PR TITLE
Feature/backup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "swankit"
-version = "0.2.0"
+version = "0.2.1"
 dynamic = ["readme", "dependencies"]
 description = "Base toolkit for SwanLab"
 license = "Apache-2.0"

--- a/swankit/callback/__init__.py
+++ b/swankit/callback/__init__.py
@@ -42,7 +42,6 @@ class SwanKitCallback(ABC):
         run_id: str,
         exp_name: str,
         description: str,
-        num: int,
         colors: Tuple[str, str],
         *args,
         **kwargs,
@@ -52,7 +51,6 @@ class SwanKitCallback(ABC):
         :param run_id: str, SwanLabRun的运行id
         :param exp_name: str, 实验名称
         :param description: str, 实验描述
-        :param num: int, 历史实验数量
         :param colors: Tuple[str, str], 实验颜色，[light, dark]
         """
         pass

--- a/swankit/callback/__init__.py
+++ b/swankit/callback/__init__.py
@@ -20,11 +20,12 @@ class SwanKitCallback(ABC):
     此处只定义会被调用的函数，用于接口规范
     """
 
-    def on_init(self, proj_name: str, workspace: str, logdir: str = None, *args, **kwargs):
+    def on_init(self, proj_name: str, workspace: str, public: bool = None, logdir: str = None, *args, **kwargs):
         """
         执行`swanlab.init`时调用，此时运行时环境变量没有被设置，此时修改环境变量还是有效的
         :param logdir: str, 用户设置的日志目录
         :param proj_name: str, 项目名称
+        :param public: bool, 是否为公开项目
         :param workspace: str, 工作空间
         :param kwargs: dict, 其他参数，为了增加灵活性，可以在on_init的时候设置一些其他类内参数
         """

--- a/swankit/env.py
+++ b/swankit/env.py
@@ -22,7 +22,7 @@ class SwanLabMode(Enum):
 
     DISABLED = "disabled"
     CLOUD = "cloud"
-    CLOUD_ONLY = "cloud-only"
+    BACKUP = "backup"
     LOCAL = "local"
 
     @classmethod
@@ -49,7 +49,7 @@ class SwanLabSharedEnv(Enum):
     """
     SWANLAB_MODE = "SWANLAB_MODE"
     """
-    swanlab的解析模式，涉及操作员注册的回调，目前有三种：local、cloud、disabled，默认为cloud
+    swanlab的解析模式，涉及操作员注册的回调，目前有四种：local、cloud、disabled 和 backup，默认为cloud
     大小写不敏感
     """
 


### PR DESCRIPTION
This pull request introduces updates to the `swankit` project, including changes to versioning, callback function parameters, and environment modes. The most notable changes involve adding a new environment mode (`BACKUP`) and modifying callback functions to enhance flexibility and usability.

### Versioning Update:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L12-R12): Updated the project version from `0.2.0` to `0.2.1`.

### Callback Function Enhancements:
* [`swankit/callback/__init__.py`](diffhunk://#diff-2d915df8a45d3b511d3c1dbee14ae4e18a2a07931166ad2fdf8e8d067228545dL23-R28): Added a new `public` parameter to the `on_init` method in the `SwanKitCallback` class, allowing specification of whether the project is public.
* [`swankit/callback/__init__.py`](diffhunk://#diff-2d915df8a45d3b511d3c1dbee14ae4e18a2a07931166ad2fdf8e8d067228545dL45): Removed the `num` parameter from the `before_init_experiment` method, simplifying the function signature. [[1]](diffhunk://#diff-2d915df8a45d3b511d3c1dbee14ae4e18a2a07931166ad2fdf8e8d067228545dL45) [[2]](diffhunk://#diff-2d915df8a45d3b511d3c1dbee14ae4e18a2a07931166ad2fdf8e8d067228545dL55)

### Environment Mode Updates:
* [`swankit/env.py`](diffhunk://#diff-35a11b8f7cd6d03df80efc09b3e4fcbf2329676dc57170563ed206d84b5ba141L25-R25): Replaced the `CLOUD_ONLY` mode with a new `BACKUP` mode in the `SwanLabMode` enum.
* [`swankit/env.py`](diffhunk://#diff-35a11b8f7cd6d03df80efc09b3e4fcbf2329676dc57170563ed206d84b5ba141L52-R52): Updated the documentation for the `SwanLabSharedEnv` enum to reflect the addition of the `BACKUP` mode.
